### PR TITLE
feat: 添加自动删除已合并分支的 GitHub Action

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -1,0 +1,92 @@
+name: Auto Delete Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    # 只在 PR 被合并后执行，不在单纯关闭时执行
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Delete merged branch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = context.payload.pull_request.head.ref;
+            const headRepoOwner = context.payload.pull_request.head.repo?.owner?.login;
+
+            // 检查是否是 fork 的 PR
+            if (headRepoOwner && headRepoOwner !== owner) {
+              console.log(`Skipping branch deletion: PR from fork (${headRepoOwner}/${branch})`);
+              return;
+            }
+
+            // 检查是否是保护分支
+            const protectedBranches = ['main', 'master', 'develop', 'staging', 'production'];
+            if (protectedBranches.includes(branch)) {
+              console.log(`Skipping deletion of protected branch: ${branch}`);
+              return;
+            }
+
+            try {
+              // 删除分支
+              await github.rest.git.deleteRef({
+                owner: owner,
+                repo: repo,
+                ref: `heads/${branch}`
+              });
+
+              console.log(`✅ Successfully deleted branch: ${branch}`);
+
+              // 在 PR 中添加评论
+              await github.rest.issues.createComment({
+                owner: owner,
+                repo: repo,
+                issue_number: context.payload.pull_request.number,
+                body: `🗑️ Branch \`${branch}\` has been automatically deleted after merge.`
+              });
+
+            } catch (error) {
+              console.error(`Failed to delete branch ${branch}:`, error.message);
+
+              // 如果删除失败，也在 PR 中添加评论
+              if (error.status === 403) {
+                await github.rest.issues.createComment({
+                  owner: owner,
+                  repo: repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `⚠️ Could not delete branch \`${branch}\` - insufficient permissions. You may need to delete it manually.`
+                });
+              } else if (error.status === 422) {
+                console.log(`Branch ${branch} may be protected or already deleted.`);
+              }
+            }
+
+  # 处理 PR 被关闭但未合并的情况（可选）
+  notify-closed:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == false
+
+    steps:
+      - name: Comment on closed PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `ℹ️ This PR was closed without merging. Branch \`${branch}\` has been kept. \n\nIf you want to delete it manually, run:\n\`\`\`bash\ngit push origin --delete ${branch}\n\`\`\``
+            });

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,20 @@
+name: Delete Merged Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Delete merged branch
+        uses: SvanBoxel/delete-merged-branch@v1.4.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 排除的分支（不会被删除）
+          exclude: main, master, develop, staging, production
+          # 删除分支后发送通知
+          delete_closed_pr: false


### PR DESCRIPTION
## 功能描述
添加自动删除已合并分支的 GitHub Actions 工作流，提高分支管理效率。

## 包含的工作流

### 1. 自定义脚本版 (`auto-delete-branch.yml`)
- ✅ 完整的错误处理
- ✅ PR 评论通知
- ✅ 保护分支检查 (main, master, develop, staging, production)
- ✅ Fork PR 安全检查
- ✅ 合并成功后自动删除分支
- ✅ 关闭但未合并时保留分支并提醒

### 2. 简化版 (`delete-merged-branch.yml`)
- ✅ 使用第三方 Action (SvanBoxel/delete-merged-branch)
- ✅ 配置更简单
- ✅ 稳定可靠

## 触发条件
- **触发事件**: PR 被关闭时
- **执行条件**: 仅在 PR 被合并时删除分支
- **保护机制**: 重要分支不会被删除

## 权限要求
- `contents: write` - 删除分支需要
- `pull-requests: read` - 读取 PR 信息

## 测试计划
- [ ] 创建测试分支并提交 PR
- [ ] 合并 PR 验证分支自动删除
- [ ] 关闭未合并 PR 验证分支保留
- [ ] 测试保护分支不被删除

## 预期效果
1. ✅ 减少仓库中的陈旧分支
2. ✅ 自动化分支清理流程
3. ✅ 保持分支列表整洁
4. ✅ 避免手动删除分支的遗漏