### PR TITLE
fix: 优化自动删除分支工作流，解决竞态条件问题

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -38,27 +38,55 @@ jobs:
             }
 
             try {
-              // 删除分支
-              await github.rest.git.deleteRef({
-                owner: owner,
-                repo: repo,
-                ref: `heads/${branch}`
-              });
+              // 首先检查分支是否还存在
+              let branchExists = false;
+              try {
+                await github.rest.git.getRef({
+                  owner: owner,
+                  repo: repo,
+                  ref: `heads/${branch}`
+                });
+                branchExists = true;
+              } catch (checkError) {
+                if (checkError.status === 404) {
+                  console.log(`✅ Branch ${branch} already deleted (possibly by GitHub auto-delete)`);
 
-              console.log(`✅ Successfully deleted branch: ${branch}`);
+                  // 在 PR 中添加评论说明分支已被删除
+                  await github.rest.issues.createComment({
+                    owner: owner,
+                    repo: repo,
+                    issue_number: context.payload.pull_request.number,
+                    body: `✅ Branch \`${branch}\` was automatically cleaned up after merge.`
+                  });
+                  return;
+                } else {
+                  throw checkError;
+                }
+              }
 
-              // 在 PR 中添加评论
-              await github.rest.issues.createComment({
-                owner: owner,
-                repo: repo,
-                issue_number: context.payload.pull_request.number,
-                body: `🗑️ Branch \`${branch}\` has been automatically deleted after merge.`
-              });
+              if (branchExists) {
+                // 分支存在，尝试删除
+                await github.rest.git.deleteRef({
+                  owner: owner,
+                  repo: repo,
+                  ref: `heads/${branch}`
+                });
+
+                console.log(`✅ Successfully deleted branch: ${branch}`);
+
+                // 在 PR 中添加评论
+                await github.rest.issues.createComment({
+                  owner: owner,
+                  repo: repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `🗑️ Branch \`${branch}\` has been automatically deleted after merge.`
+                });
+              }
 
             } catch (error) {
               console.error(`Failed to delete branch ${branch}:`, error.message);
 
-              // 如果删除失败，也在 PR 中添加评论
+              // 如果删除失败，根据错误类型处理
               if (error.status === 403) {
                 await github.rest.issues.createComment({
                   owner: owner,
@@ -67,7 +95,29 @@ jobs:
                   body: `⚠️ Could not delete branch \`${branch}\` - insufficient permissions. You may need to delete it manually.`
                 });
               } else if (error.status === 422) {
-                console.log(`Branch ${branch} may be protected or already deleted.`);
+                console.log(`Branch ${branch} may be protected or invalid.`);
+                await github.rest.issues.createComment({
+                  owner: owner,
+                  repo: repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `ℹ️ Branch \`${branch}\` could not be deleted (may be protected).`
+                });
+              } else if (error.status === 404) {
+                console.log(`Branch ${branch} not found - may have been already deleted.`);
+                await github.rest.issues.createComment({
+                  owner: owner,
+                  repo: repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `✅ Branch \`${branch}\` was already cleaned up.`
+                });
+              } else {
+                // 其他未知错误
+                await github.rest.issues.createComment({
+                  owner: owner,
+                  repo: repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: `❌ Error occurred while cleaning up branch \`${branch}\`: ${error.message}`
+                });
               }
             }
 

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,8 +1,12 @@
-name: Delete Merged Branch
+name: Delete Merged Branch (Simple)
 
 on:
   pull_request:
     types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   delete-branch:
@@ -11,10 +15,22 @@ jobs:
 
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@v1.4.3
+        uses: SvanBoxel/delete-merged-branch@v2.0.2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # 排除的分支（不会被删除）
-          exclude: main, master, develop, staging, production
-          # 删除分支后发送通知
-          delete_closed_pr: false
+          ignore_branches: main,master,develop,staging,production
+
+      - name: Comment on successful deletion
+        uses: actions/github-script@v7
+        if: success()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `🗑️ Branch \`${branch}\` has been automatically deleted after merge.`
+            });


### PR DESCRIPTION
## 问题描述
在 PR #2 合并后，自动删除分支的 Action 出现错误：
```
⚠️ Could not delete branch `add-auto-delete-workflow` - insufficient permissions.
```

但实际上分支已经被成功删除，这是一个竞态条件问题。

## 根本原因
1. **GitHub 自动删除**: GitHub 在 PR 合并时可能自动删除分支
2. **Action 执行延迟**: Action 尝试删除时分支已经不存在
3. **API 调用时序**: 分支状态检查和删除操作之间的时间窗口

## 解决方案

### 🔧 自定义脚本版 (`auto-delete-branch.yml`)
- ✅ **分支存在性检查**: 删除前先检查分支是否存在
- ✅ **改进错误处理**: 区分不同错误类型并提供合适反馈
- ✅ **智能反馈**: 分支已删除时显示正面消息而非错误

```javascript
// 新增分支检查逻辑
try {
  await github.rest.git.getRef({
    owner: owner,
    repo: repo,
    ref: `heads/${branch}`
  });
  branchExists = true;
} catch (checkError) {
  if (checkError.status === 404) {
    console.log(`✅ Branch ${branch} already deleted`);
    return; // 分支已删除，正常退出
  }
}
```

### 🔧 简化版 (`delete-merged-branch.yml`)
- ✅ **升级版本**: 使用 SvanBoxel/delete-merged-branch@v2.0.2
- ✅ **更新参数**: github_token, ignore_branches (新版本参数)
- ✅ **权限优化**: 添加 pull-requests: write 权限
- ✅ **成功通知**: 删除成功后添加 PR 评论

## 测试计划
- [ ] 创建测试分支并合并 PR
- [ ] 验证分支正常删除且无错误
- [ ] 测试 GitHub 自动删除的情况处理
- [ ] 验证保护分支不被删除

## 预期效果
1. ✅ 消除误报错误
2. ✅ 提供准确的状态反馈
3. ✅ 处理各种边界情况
4. ✅ 保持分支清理功能正常

## 验证方式
合并此 PR 后，`fix-auto-delete-workflow` 分支应该被正确删除，且不会出现权限错误。