### PR TITLE
fix: 移除PR评论功能，解决权限错误

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
 
 jobs:
   delete-branch:
@@ -47,19 +46,13 @@ jobs:
                   ref: `heads/${branch}`
                 });
                 branchExists = true;
+                console.log(`Branch ${branch} exists, proceeding with deletion`);
               } catch (checkError) {
                 if (checkError.status === 404) {
                   console.log(`✅ Branch ${branch} already deleted (possibly by GitHub auto-delete)`);
-
-                  // 在 PR 中添加评论说明分支已被删除
-                  await github.rest.issues.createComment({
-                    owner: owner,
-                    repo: repo,
-                    issue_number: context.payload.pull_request.number,
-                    body: `✅ Branch \`${branch}\` was automatically cleaned up after merge.`
-                  });
                   return;
                 } else {
+                  console.log(`Error checking branch existence: ${checkError.message}`);
                   throw checkError;
                 }
               }
@@ -73,70 +66,22 @@ jobs:
                 });
 
                 console.log(`✅ Successfully deleted branch: ${branch}`);
-
-                // 在 PR 中添加评论
-                await github.rest.issues.createComment({
-                  owner: owner,
-                  repo: repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: `🗑️ Branch \`${branch}\` has been automatically deleted after merge.`
-                });
               }
 
             } catch (error) {
               console.error(`Failed to delete branch ${branch}:`, error.message);
 
-              // 如果删除失败，根据错误类型处理
+              // 不要尝试添加评论，只记录错误
               if (error.status === 403) {
-                await github.rest.issues.createComment({
-                  owner: owner,
-                  repo: repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: `⚠️ Could not delete branch \`${branch}\` - insufficient permissions. You may need to delete it manually.`
-                });
+                console.error(`❌ Insufficient permissions to delete branch ${branch}`);
               } else if (error.status === 422) {
-                console.log(`Branch ${branch} may be protected or invalid.`);
-                await github.rest.issues.createComment({
-                  owner: owner,
-                  repo: repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: `ℹ️ Branch \`${branch}\` could not be deleted (may be protected).`
-                });
+                console.log(`⚠️ Branch ${branch} may be protected or invalid`);
               } else if (error.status === 404) {
-                console.log(`Branch ${branch} not found - may have been already deleted.`);
-                await github.rest.issues.createComment({
-                  owner: owner,
-                  repo: repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: `✅ Branch \`${branch}\` was already cleaned up.`
-                });
+                console.log(`ℹ️ Branch ${branch} not found - may have been already deleted`);
               } else {
-                // 其他未知错误
-                await github.rest.issues.createComment({
-                  owner: owner,
-                  repo: repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: `❌ Error occurred while cleaning up branch \`${branch}\`: ${error.message}`
-                });
+                console.error(`❌ Unexpected error: ${error.message}`);
               }
+
+              // 重新抛出错误以标记 Action 失败
+              throw error;
             }
-
-  # 处理 PR 被关闭但未合并的情况（可选）
-  notify-closed:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == false
-
-    steps:
-      - name: Comment on closed PR
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const branch = context.payload.pull_request.head.ref;
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: `ℹ️ This PR was closed without merging. Branch \`${branch}\` has been kept. \n\nIf you want to delete it manually, run:\n\`\`\`bash\ngit push origin --delete ${branch}\n\`\`\``
-            });

--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   delete-branch:
@@ -20,17 +19,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # 排除的分支（不会被删除）
           ignore_branches: main,master,develop,staging,production
-
-      - name: Comment on successful deletion
-        uses: actions/github-script@v7
-        if: success()
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const branch = context.payload.pull_request.head.ref;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: `🗑️ Branch \`${branch}\` has been automatically deleted after merge.`
-            });


### PR DESCRIPTION
## 🔍 错误根因分析

通过详细的错误日志分析，发现问题不在分支删除，而在 **PR 评论权限**：

```
POST https://api.github.com/repos/suichou8/strategy-ios-claude-code/issues/3/comments
'x-accepted-github-permissions': 'issues=write; pull_requests=write'
Resource not accessible by integration (403)
```

## 🚨 问题确认

1. **分支删除成功** - 实际上分支已被正确删除
2. **评论添加失败** - GitHub Actions 的 `GITHUB_TOKEN` 对 PR 评论权限不足
3. **误导性错误** - 真正失败的是评论创建，不是分支删除

## ✅ 解决方案

### 方案：移除 PR 评论功能

**自定义脚本版** (`auto-delete-branch.yml`):
- ❌ 移除所有 `github.rest.issues.createComment` 调用
- ✅ 保留分支存在性检查
- ✅ 保留详细的 console.log 输出
- ✅ 保留错误分类和处理

**简化版** (`delete-merged-branch.yml`):
- ❌ 移除成功后的评论步骤
- ✅ 纯粹依赖第三方 Action
- ✅ 最小权限要求：只需 `contents: write`

## 🎯 权限优化

**之前** (导致权限错误):
```yaml
permissions:
  contents: write
  pull-requests: write  # 实际上无效
```

**现在** (最小权限):
```yaml
permissions:
  contents: write  # 仅需分支删除权限
```

## ✨ 预期效果

1. ✅ 分支正常自动删除
2. ✅ 无权限错误
3. ✅ 清晰的日志输出
4. ✅ 保护分支安全检查

## 🧪 测试验证

合并此 PR 后：
- `simple-auto-delete` 分支应被自动删除
- Action 应成功完成，无任何错误
- 日志中显示 `✅ Successfully deleted branch`