### PR TITLE
fix: Remove empty PROVISIONING_PROFILE_SPECIFIER to use xcconfig value

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -123,7 +123,6 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM=YWCR255LN4 \
             CODE_SIGN_IDENTITY="Apple Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="" \
             clean archive
 
           echo "✅ Archive 构建完成"


### PR DESCRIPTION
## 问题描述

GitHub Actions 部署在 Build Archive 步骤失败，错误信息：
```
error: "CatchTrend" requires a provisioning profile.
```

## 根本原因

`.github/workflows/deploy-testflight.yml` 中的 `PROVISIONING_PROFILE_SPECIFIER=""` 参数覆盖了 `Configs/Release.xcconfig` 中的配置：

```xcconfig
PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = CatchTrend AppStore Profile
```

命令行参数的优先级高于 xcconfig 配置，空字符串导致 Xcode 无法找到 Provisioning Profile。

## 修复方案

从 workflow 的 Build Archive 步骤中移除 `PROVISIONING_PROFILE_SPECIFIER=""` 参数，让 xcconfig 配置生效。

## 测试计划

Merge 此 PR 后，需要重新触发部署：
1. 删除现有 tag: `git tag -d v1.0.0 && git push origin :refs/tags/v1.0.0`
2. 重新创建 tag: `git tag v1.0.0 && git push origin v1.0.0`
3. 监控 GitHub Actions 工作流执行

## 变更文件

- `.github/workflows/deploy-testflight.yml` - 移除空的 PROVISIONING_PROFILE_SPECIFIER 参数

🤖 Generated with [Claude Code](https://claude.com/claude-code)