### PR TITLE
fix: Add provisioningProfiles to ExportOptions.plist

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -147,6 +147,11 @@ jobs:
             <false/>
             <key>signingStyle</key>
             <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>com.sunshinenew07.CatchTrend</key>
+              <string>CatchTrend AppStore Profile</string>
+            </dict>
           </dict>
           </plist>
           PLIST


### PR DESCRIPTION
## 问题描述

Export IPA 步骤失败，错误信息：
```
error: exportArchive "CatchTrend.app" requires a provisioning profile.
** EXPORT FAILED **
Error: Process completed with exit code 70.
```

## 根本原因

Build Archive 步骤已经成功，但是 Export IPA 步骤失败。原因是 ExportOptions.plist 中缺少 `provisioningProfiles` 配置。

对于手动签名（`signingStyle: manual`），必须在 ExportOptions.plist 中明确指定每个 Bundle ID 对应的 Provisioning Profile 名称。

## 修复方案

在 ExportOptions.plist 中添加 `provisioningProfiles` 字典：

```xml
<key>provisioningProfiles</key>
<dict>
  <key>com.sunshinenew07.CatchTrend</key>
  <string>CatchTrend AppStore Profile</string>
</dict>
```

这样 xcodebuild 在导出 IPA 时就知道使用哪个 Provisioning Profile 进行签名。

## 变更文件

- `.github/workflows/deploy-testflight.yml` - 在 ExportOptions.plist 中添加 provisioningProfiles 配置

## 参考文档

- [Xcode Build Configuration - Export Options](https://developer.apple.com/documentation/xcode/build-settings-reference)
- ExportOptions.plist 手动签名要求

🤖 Generated with [Claude Code](https://claude.com/claude-code)