### PR TITLE
fix: Add contents write permission for GitHub Releases

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -7,6 +7,9 @@ on:
       - 'v*.*.*-beta.*'    # 匹配 v1.0.0-beta.1 等格式
   workflow_dispatch:       # 允许手动触发
 
+permissions:
+  contents: write          # 允许创建 GitHub Releases 和上传 artifacts
+
 env:
   XCODE_VERSION: '26.0'
   SCHEME: 'CatchTrend'


### PR DESCRIPTION
## 问题描述

创建 GitHub Release 步骤失败，错误信息：
```
⚠️ GitHub release failed with status: 403
undefined
retrying... (2 retries remaining)
...
❌ Too many retries. Aborting...
Error: Too many retries.
```

## 根本原因

GitHub Actions 从安全角度考虑，默认的 `GITHUB_TOKEN` 权限是受限的。如果 workflow 需要创建 Releases 或上传 artifacts，必须显式声明 `permissions`。

403 错误表示 workflow 没有足够的权限来执行创建 Release 的操作。

## 修复方案

在 workflow 文件顶部添加 `permissions` 配置：

```yaml
permissions:
  contents: write  # 允许创建 GitHub Releases 和上传 artifacts
```

这样 GitHub Actions 就有权限执行：
- 创建 GitHub Releases (`softprops/action-gh-release@v1`)
- 上传 artifacts (`actions/upload-artifact@v4`)

## 变更文件

- `.github/workflows/deploy-testflight.yml` - 添加 permissions.contents: write

## 参考文档

- [GitHub Actions Permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
- [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)